### PR TITLE
Add Go Gin Starter Kit for Microservice/BFF and Edge scenarios

### DIFF
--- a/public/data/links.json
+++ b/public/data/links.json
@@ -53,10 +53,10 @@
   ],
   "codepatterns" : [
   {"title":"React UI Patterns", "subtitle":"Carbon based UI to help with common patterns using React framework","language":"React","href":"https://github.com/IBM/template-node-react","color":"light"},
-  {"title":"Angular UI Patterns", "subtitle":"Carbon based UI to help with common patterns using Angular framework","language":"Angular","href":"https://github.com/IBM/template-node-angular","color":"light"},
   {"title":"Typescript GraphQL", "subtitle":"Node.js TypeScript GraphQL Backend for Frontend","language":"TypeScript","href":"https://github.com/IBM/template-graphql-typescript","color":"light"},
   {"title":"Typescript Microservice", "subtitle":"Node.js TypeScript Microservice offering OpenAPI endpoints","language":"TypeScript","href":"https://github.com/IBM/template-node-typescript","color":"light"},
-  {"title":"Spring Boot Microservice", "subtitle":"Spring Boot Java Microservices","language":"Java","href":"https://github.com/IBM/template-java-spring","color":"light"}
+  {"title":"Spring Boot Microservice", "subtitle":"Spring Boot Java Microservice","language":"Java","href":"https://github.com/IBM/template-java-spring","color":"light"},
+  {"title":"Go Gin Microservice", "subtitle":"Go Gin Microservice/Edge","language":"Go","href":"https://github.com/IBM/template-go-gin","color":"light"}
   ],
   "argocd" : [
     {"title":"ArgoCD GitOps", "subtitle":"ArgoCD GitOps Template to help set up your CD pipeline","language":"YAML","href":"https://github.com/IBM/template-argocd-gitops","color":"grey"},


### PR DESCRIPTION
Add Go-Gin Starter Kit to list of supported Starter Kits to enable Edge use cases
Add TOOLS.MD to document how to customize the Header of the Dashboard