### PR TITLE
Adds test to load kube config from local env instead of cluster

### DIFF
--- a/server/routers/kubernetes-client.js
+++ b/server/routers/kubernetes-client.js
@@ -4,7 +4,12 @@ const Request = require('kubernetes-client/backends/request');
 module.exports = function() {
 
   const kubeconfig = new KubeConfig();
-  kubeconfig.loadFromCluster();
+  if (process.env.DEV === 'true') {
+    kubeconfig.loadFromDefault();
+  } else {
+    kubeconfig.loadFromCluster();
+  }
+
   const backend = new Request({kubeconfig});
 
   return new Client({backend, version: '1.13'});


### PR DESCRIPTION
Set `DEV` environment variable to `true` and configuration will be loaded from default location