### PR TITLE
Fix reference to master branch in default LINKS_URL and in docs

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
     branches: [ main ]
@@ -13,7 +13,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ npm run api:test
 
 #### Creating a release
 
-This repository uses GitHub actions to automatically create a release whenever a change is pushed to `master`. The workflow for changes should follow a typical process:
+This repository uses GitHub actions to automatically create a release whenever a change is pushed to `main`. The workflow for changes should follow a typical process:
 
 1. Create a branch (ideally in a fork of the repository)
 
-2. Create a pull-request to merge the changes from the branch into `master`. Add a release label (`major`, `minor`, `patch`) and a change type label (`feature`, `bug`, `chore`) to the pull request to effect the new release tag that is generated and how the change log is generated for the release.
+2. Create a pull-request to merge the changes from the branch into `main`. Add a release label (`major`, `minor`, `patch`) and a change type label (`feature`, `bug`, `chore`) to the pull request to effect the new release tag that is generated and how the change log is generated for the release.
 
-3. Merge the pull-request into master. This will trigger the workflow to create the release.
+3. Merge the pull-request into `main`. This will trigger the workflow to create the release.
 
 #### Building the container image
 
 This repository is also connected to the Docker Hub build image. The build process has been configured with two rules:
 
-1. Any time a change is pushed to `master`, a new image is built with the `latest` tag
+1. Any time a change is pushed to `main`, a new image is built with the `latest` tag
 2. Any time a new release is created for the repository, a new image is built with a tag that matches the repository tag (e.g. git tag v1.1.1 -> docker tag 1.1.1)
 
 #### Updating the Dashboard terraform module

--- a/server/routers/activation.js
+++ b/server/routers/activation.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
     if (fileJSONLINKS) {
       return res.json(JSON.parse(fileJSONLINKS))
     }
-    const activation = process.env.LINKS_URL || 'https://raw.githubusercontent.com/ibm-garage-cloud/developer-dashboard/master/public/data/links.json'
+    const activation = process.env.LINKS_URL || 'https://raw.githubusercontent.com/ibm-garage-cloud/developer-dashboard/main/public/data/links.json'
 
     // Get the Activation links
     rp({


### PR DESCRIPTION
The master branch was renamed to main but the code still references the master branch. For a period of time we have (and will continue for a while) maintained the master branch with the latest from the main branch until all the old instances of the dashboard have been updated.

However, the new version of the dashboard should point to main and not master so that we can at some point retire the master branch. (Also I forgot about this and was wondering why my changes in main weren't showing up!!)